### PR TITLE
Progress bar transitions

### DIFF
--- a/source/tamasha/macros/progressbar.tid
+++ b/source/tamasha/macros/progressbar.tid
@@ -4,8 +4,8 @@ tags: $:/tags/Macro/Tamasha
 title: $:/plugins/kookma/tamasha/macros/progressbar
 type: text/vnd.tiddlywiki
 
-\define progress(pct)
+\define progress()
 <div class="tamasha-progress">
-	<span class="bar" style="transform:scaleX($pct$);"></span>
+	<span class="bar" style={{{ [tag<mainTag>allbefore:include{$(stateNavigatorTid)$!!text}count[]divide<numberSlides>fixed[2]addprefix[transform:scaleX(]addsuffix[);]]}}}></span>
 </div>
 \end

--- a/source/tamasha/ui/progressbar.tid
+++ b/source/tamasha/ui/progressbar.tid
@@ -4,4 +4,4 @@ tags:
 title: $:/plugins/kookma/tamasha/ui/progressbar
 type: text/vnd.tiddlywiki
 
-<<progressbar>>
+<<progress>>

--- a/source/tamasha/ui/progressbar.tid
+++ b/source/tamasha/ui/progressbar.tid
@@ -4,6 +4,4 @@ tags:
 title: $:/plugins/kookma/tamasha/ui/progressbar
 type: text/vnd.tiddlywiki
 
-<$vars currentTid={{{[<stateNavigatorTid>get[text]] ~[tag<mainTag>first[]]}}}>
-<$macrocall $name=progress pct={{{ [tag<mainTag>allbefore:include<currentTid>count[]divide<numberSlides>fixed[2]] }}} >
-</$vars>
+<<progressbar>>


### PR DESCRIPTION
The key is NOT to wrap the element showing the progress bar with a widget that will cause it to be replaced each time the variable changes. Instead, assign a filter to the progress bar such that the styles are updated directly.

You want the styles to change. You do NOT want the element to be replaced each time.

Offtopic but you might enjoy exploring [variables in CSS](https://www.w3schools.com/css/css3_variables.asp), combined with wikitext it can be very powerful.

Fixes #4 