### PR TITLE
Dynamic font sizes part 2

### DIFF
--- a/source/tamasha/styles/layout/content.css
+++ b/source/tamasha/styles/layout/content.css
@@ -1,12 +1,17 @@
 .tamasha-slide-content {
-	/*  font-size: calc(1rem + 1.5vw);
-	line-height: calc(2rem + 1.5vw);*/
-	font-size: clamp(1rem, 2vw, 3rem);
-	line-height: clamp(1.5rem,3vw, 4.5rem);
-	padding: 60px;
-	margin: 0 auto;
-	max-width: 900px;
-	height: 600px;
-	overflow: hidden;
-	margin-bottom: 4rem;
+  font-size: 1.3rem;
+  line-height: 1.85rem;
+  padding: 30px;
+  margin: 0 auto;
+  max-width: 900px;
+  height: 600px;
+  overflow: hidden;
+  margin-bottom: 4rem;
+}
+
+.tamasha-overlay .tamasha-slide-content {
+  font-size: 3vh;
+  line-height: 5vh;
+  height: auto;
+  padding: 8vh;
 }

--- a/source/tamasha/themes/kimia.css
+++ b/source/tamasha/themes/kimia.css
@@ -1,11 +1,7 @@
 .kimia .tamasha-slide-content {	
-    font-size:20px;
-    line-height:36px;	
 }
 
 
 .kimia .tamasha-slide-content .title{ /* used with vanilla template*/
     font-weight:300;
-    font-size: 52px;
-    line-height: 52px;
 }

--- a/source/tamasha/themes/mitra.css
+++ b/source/tamasha/themes/mitra.css
@@ -6,8 +6,6 @@
 }
 
 .mitra .tamasha-slide-content{
-	font-size:32px;
-	line-height:48px;
 	font-weight:500;
 }
 

--- a/source/tamasha/themes/vanda.css
+++ b/source/tamasha/themes/vanda.css
@@ -1,15 +1,3 @@
-.vanda .tamasha-slide-content{
-/*	font-size:32px;
-	line-height:48px;
-	font-weight:500;*/
-}
-
-.vanda .tamasha-slide-content .title{ /* used with vanilla template*/
-/*	font-size:1.5em;
-	line-height:1.5em;
-	font-weight:500; */
-}
-
 /* ---------- code ---------- */
 .vanda .tamasha-slide-content  code,
 .vanda .tamasha-slide-content  pre {


### PR DESCRIPTION
Set paddings and font sizes based on `vh` in presentation mode only

* In "normal" mode, use `rem` units for font sizes
* In presentation mode, use `vh` units to scale fonts
* Remove theme font-size/line-height definitions set in px (relative font-size/line-height definitions are kept)

With the new scaled font-size, setting font sizes in px does not work anymore.

@kookma Could you checkout this branch and try it? I've played with it both on mobile and desktop, and I like the result so far, but more tweaking and testing might be needed.

With these changes, the number of lines per slide is **almost** constant in presentation and normal mode. Getting them to scale exactly the same way is tricky, as paddings/line heights and other factors come into play, but I think this is pretty close.

I'm not 100% convinced with the left/right padding on presentation mode, especially on mobile, so I might try to improve that part in a later PR.

#### Screenshots

##### Normal mode (600px height)

![2021-02-01-221326](https://user-images.githubusercontent.com/123539/106519004-f3270180-64da-11eb-9a9c-1c6245774ebe.png)

##### Mobile (presentation)

![2021-02-01-221406](https://user-images.githubusercontent.com/123539/106519044-0043f080-64db-11eb-8dc7-97d1260e1422.png)

##### Ipad (presentation)

![2021-02-01-221435](https://user-images.githubusercontent.com/123539/106519064-076afe80-64db-11eb-9383-a4837a3c39b9.png)

##### Desktop (1280px wide) presentation

![2021-02-01-221625](https://user-images.githubusercontent.com/123539/106519142-28335400-64db-11eb-8f8f-33862711d835.png)
