### PR TITLE
Dynamic font size 3

### DIFF
--- a/source/tamasha/styles/layout/content.css
+++ b/source/tamasha/styles/layout/content.css
@@ -10,8 +10,8 @@
 }
 
 .tamasha-overlay .tamasha-slide-content {
-  font-size: 3vh;
-  line-height: 5vh;
+  font-size: 4vh;
+  line-height: 6vh;
   height: auto;
   padding: 8vh;
 }

--- a/source/tamasha/styles/layout/content.css
+++ b/source/tamasha/styles/layout/content.css
@@ -10,8 +10,8 @@
 }
 
 .tamasha-overlay .tamasha-slide-content {
-  font-size: 4vh;
-  line-height: 6vh;
+  font-size: clamp(1rem, 4vh, 2.5rem);
+  line-height: clamp(1.5rem, 6vh, 4rem);
   height: auto;
   padding: 8vh;
 }


### PR DESCRIPTION
This PR further tweaks support for dynamic font sizes:

* Use slightly bigger fonts in presentation mode. Up to 8 lines are visible without overflow (which is similar to the number of visible lines in author mode)
* Clamp font sizes in presentation mode: Clamping font sizes ensures that slides are always readable, even on tiny
screens.

This PR doesn't fix the bottom padding issue with overflowing slides in presentation mode (I'm preparing another PR for that).