### PR TITLE
feat: Update vanilla.tid to use caption

### DIFF
--- a/source/tamasha/templates/vanilla.tid
+++ b/source/tamasha/templates/vanilla.tid
@@ -2,5 +2,12 @@ tags: $:/tags/Tamasha/Template
 title: $:/plugins/kookma/tamasha/templates/vanilla
 type: text/vnd.tiddlywiki
 
-<h2 class="title"><$link to=<<currentSlide>> /></h2>
+\whitespace trim
+<h2 class="title">
+  <$link to=<<currentSlide>>>
+    <$transclude field="caption">
+      <$view field="title"/>
+    </$transclude>
+  </$link>
+</h2>
 <$transclude tiddler=<<currentSlide>> mode=block/>


### PR DESCRIPTION
When using https://github.com/Jermolene/TiddlyWiki5/pull/7821 , the title will have an ugly prefix, so need to display caption, what do you think?

![图片](https://github.com/kookma/TW-Tamasha/assets/3746270/70dbe325-2b89-4e52-bdeb-5ce6c752ee10)


BTW, why use `<h2 class="title">` instead of `tc-title` class name?